### PR TITLE
feat(username): enforce username argument

### DIFF
--- a/bin/devsetup.sh
+++ b/bin/devsetup.sh
@@ -66,6 +66,12 @@ while getopts ":u:l:s:a:" option; do
 done
 shift $((OPTIND-1))
 
+if [[ -z "${DEVUSER}" ]]
+then
+    echo "Error: No user specified"
+    usage
+fi
+
 ##### PROFILE PHASE
 echo "${profile}" | grep menu >/dev/null 2>&1
 if (( $? == 0 ))


### PR DESCRIPTION
This PR makes `-u username` mandatory so `config.sls` is populated with correct user value.