### PR TITLE
feat(freebsd): support freebsd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,14 @@
 Salt Desktop
 ================
 
-Salt Desktop orchestrates useful software onto Linux/MacOS without fuss.
+Salt Desktop orchestrates useful software onto Linux/FreeBSD/MacOS without fuss.
 
 HOSTED AT https://github.com/saltstack-formulas/salt-desktop !!!!!!!
 
 Quick start
 ===========
 
-Install salt on MacOS or GNU/Linux (Ubuntu/Debian/CentOS/SuSE)::
+Install salt on MacOS, FreeBSD, or GNU/Linux (Ubuntu/Debian/CentOS/SuSE)::
 
     curl -o salt.sh https://raw.githubusercontent.com/saltstack-formulas/salt-desktop/master/bin/salt.sh && sudo bash salt.sh
 

--- a/bin/devsetup.sh
+++ b/bin/devsetup.sh
@@ -12,6 +12,12 @@ PILLARFS=/srv/pillar
 PROFILEAPI=${SALTFS}/profiles
 FORMULA_REPO=${SALTFS}/repo
 
+if [ `uname` = 'FreeBSD' ]
+then
+    SALTFS=/usr/local/etc/salt/states
+    PILLARFS=/usr/local/etc/salt/pillars
+fi
+
 usage()
 {
     echo "Usage: sudo $0 [ options ]" 1>&2

--- a/bin/devsetup.sh
+++ b/bin/devsetup.sh
@@ -9,14 +9,13 @@ loglevel='warning'
 profile='menu'
 SALTFS=/srv/salt
 PILLARFS=/srv/pillar
-PROFILEAPI=${SALTFS}/profiles
-FORMULA_REPO=${SALTFS}/repo
-
 if [ `uname` = 'FreeBSD' ]
 then
     SALTFS=/usr/local/etc/salt/states
     PILLARFS=/usr/local/etc/salt/pillars
 fi
+PROFILEAPI=${SALTFS}/profiles
+FORMULA_REPO=${SALTFS}/repo
 
 usage()
 {

--- a/bin/salt.sh
+++ b/bin/salt.sh
@@ -23,6 +23,12 @@ while getopts ":r:" option; do
 done
 shift $((OPTIND-1))
 
+if [ `uname` = 'FreeBSD' ]
+then
+    SALTFS=/usr/local/etc/salt/states
+    mkdir -p ${SALTFS} 2>/dev/null
+fi
+
 case "$OSTYPE" in
 darwin*) OSHOME=/Users
          USER=$( stat -f "%Su" /dev/console )

--- a/bin/salt.sh
+++ b/bin/salt.sh
@@ -87,14 +87,14 @@ freebsd*|linux*)
              /usr/bin/pacman -Syyu --noconfirm
              /usr/bin/pacman -S --noconfirm git python-yaml python-pip psutils || exit 1
          elif [ -f "/usr/sbin/pkg" ]; then
-             /usr/sbin/pkg update -f -y
-             /usr/sbin/pkg install -y git py36-pip wget
+             export DEFAULT_ALWAYS_YES=true
+             /usr/sbin/pkg update -f
+             /usr/sbin/pkg install git py36-pip wget
          fi
          pip install --user --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          rm -f install_salt.sh 2>/dev/null
          wget -O install_salt.sh https://bootstrap.saltstack.com || exit 1
          (sh install_salt.sh -P ${RELEASE} && rm -f install_salt.sh) || exit 1
-         ;;
 esac
 
 echo "Clone salt-desktop ..."

--- a/bin/salt.sh
+++ b/bin/salt.sh
@@ -110,11 +110,11 @@ echo
 echo "For usage ideas visit ..."
 echo " https://github.com/saltstack-formulas/salt-desktop#stack-profiles"
 echo
-echo "\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"
-echo "////////////                                             \\\\\\\\\\\\\\\\"
-echo "\\\\\\\\\\\               Congratulations                ////////////////"
-echo "///////////     Salt and Salt-Desktop are installed      \\\\\\\\\\\\\\\\"
-echo "///////////                                              ////////////////"
+echo "////////////////////////////////////////////////////////////////////////"
+echo "///////////                                              ///////////////"
+echo "///////////               Congratulations                ///////////////"
+echo "///////////     Salt and Salt-Desktop are installed      ///////////////"
+echo "///////////                                              ///////////////"
 echo "////////////////////////////////////////////////////////////////////////"
 echo
 echo


### PR DESCRIPTION
```Setup FreeBSD baseline and install saltstack masterless minion ...
Updating FreeBSD repository catalogue...
Fetching meta.txz: 100%    944 B   0.9kB/s    00:01    
Fetching packagesite.txz: 100%    6 MiB  45.3kB/s    02:25    
Processing entries: 100%
FreeBSD repository update completed. 31898 packages processed.
Updating SaltStack repository catalogue...
Fetching meta.txz: 100%    560 B   0.6kB/s    00:01    
Fetching packagesite.txz: 100%   19 KiB  19.3kB/s    00:01    
Processing entries: 100%
SaltStack repository update completed. 65 packages processed.
All repositories are up to date.
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
Updating SaltStack repository catalogue...
SaltStack repository is up to date.
All repositories are up to date.
Checking integrity... done (0 conflicting)
The most recent versions of packages are already installed
Collecting wrapper
  Using cached https://files.pythonhosted.org/packages/91/91/dadfbf7cb069b082498706ab1c2ddec44899165d2134d65d4305c664b5bc/Wrapper-1.1.0b1.tar.gz
Collecting barcodenumber
  Using cached https://files.pythonhosted.org/packages/1b/fb/650460a147195daa737ddc044e5894c7d4a9875ac6a002f9a07b713b341d/barcodenumber-0.2.1.tar.gz
Collecting npyscreen
  Using cached https://files.pythonhosted.org/packages/93/48/91b8321280f17d135918895b57f891f727be84a88f62fc62485a7039de00/npyscreen-4.10.5.tar.gz
Installing collected packages: wrapper, barcodenumber, npyscreen
  Running setup.py install for wrapper ... done
  Running setup.py install for barcodenumber ... done
  Running setup.py install for npyscreen ... done
Successfully installed barcodenumber-0.2.1 npyscreen-4.10.5 wrapper-1.1.0b1
You are using pip version 9.0.3, however version 19.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
--2019-06-22 22:45:46--  https://bootstrap.saltstack.com/
Resolving bootstrap.saltstack.com (bootstrap.saltstack.com)... 13.249.198.93, 13.249.198.128, 13.249.198.6, ...
Connecting to bootstrap.saltstack.com (bootstrap.saltstack.com)|13.249.198.93|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://bootstrap.saltstack.com/stable/bootstrap-salt.sh [following]
--2019-06-22 22:45:49--  https://bootstrap.saltstack.com/stable/bootstrap-salt.sh
Reusing existing connection to bootstrap.saltstack.com:443.
HTTP request sent, awaiting response... 200 OK
Length: 266421 (260K) [application/x-sh]
Saving to: 'install_salt.sh'

install_salt.sh                     100%[================================================================>] 260.18K   113KB/s    in 2.3s    

2019-06-22 22:45:52 (113 KB/s) - 'install_salt.sh' saved [266421/266421]

 *  INFO: Running version: 2019.05.20
 *  INFO: Executed by: shell pipe
 *  INFO: Command line: 'install_salt.sh -P'

 *  INFO: System Information:
 *  INFO:   CPU:          Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
 *  INFO:   CPU Arch:     amd64
 *  INFO:   OS Name:      FreeBSD
 *  INFO:   OS Version:   11.2-RELEASE
 *  INFO:   Distribution: FreeBSD 11.2

 *  INFO: Installing minion
 *  INFO: Found function install_freebsd_11_stable_deps
 *  INFO: Found function config_salt
 *  INFO: Found function preseed_master
 *  INFO: Found function install_freebsd_11_stable
 *  INFO: Found function install_freebsd_11_stable_post
 *  INFO: Found function install_freebsd_restart_daemons
 *  INFO: Found function daemons_running
 *  INFO: Running install_freebsd_11_stable_deps()
Updating FreeBSD repository catalogue...
Fetching meta.txz: . done
Fetching packagesite.txz: .......... done
Processing entries: .......... done
FreeBSD repository update completed. 31898 packages processed.
Updating SaltStack repository catalogue...
Fetching meta.txz: . done
Fetching packagesite.txz: ... done
Processing entries: ....... done
SaltStack repository update completed. 65 packages processed.
All repositories are up to date.
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
Checking integrity... done (0 conflicting)
The most recent versions of packages are already installed
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
Checking integrity... done (0 conflicting)
The most recent versions of packages are already installed
 *  INFO: Running install_freebsd_11_stable()
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
Checking integrity... done (1 conflicting)
  - py36-salt-2019.2.0_1 [FreeBSD] conflicts with py27-salt-2019.2.0_1 [installed] on /usr/local/etc/salt/master.sample
Checking integrity... done (0 conflicting)
The following 2 package(s) will be affected (of 0 checked):

Installed packages to be REMOVED:
	py27-salt-2019.2.0_1

New packages to be INSTALLED:
	py36-salt: 2019.2.0_1 [FreeBSD]

Number of packages to be removed: 1
Number of packages to be installed: 1

The operation will free 6 MiB.
[1/2] Deinstalling py27-salt-2019.2.0_1...
[1/2] Deleting files for py27-salt-2019.2.0_1: .......... done
[2/2] Installing py36-salt-2019.2.0_1...
[2/2] Extracting py36-salt-2019.2.0_1: .......... done
Message from py36-salt-2019.2.0_1:

===================================================================================================

To configure a Salt Master, do the following:

  o Copy /usr/local/etc/salt/master.sample to /usr/local/etc/salt/master
  o Update to meet your needs
  o sysrc salt_master_enable="YES"

---------------------------------------------------------------------------------------------------

To configure a Salt Minion, do the following:

  o Copy /usr/local/etc/salt/minion.sample to /usr/local/etc/salt/minion
  o Update 'master: salt' to point to your Salt Master's hostname or IP
  o sysrc salt_minion_enable="YES"

---------------------------------------------------------------------------------------------------

To configure a Salt Proxy Minion, do the following:

  o sysrc salt_proxy_enable="YES"
  o sysrc salt_proxy_list=""
  o Update the salt_proxy_list with the proxy minion name(s)

---------------------------------------------------------------------------------------------------

To change the Transport method from the default option of Zeromq to either TCP or RAET:

  o Re-build the port with the desired options enabled to install the correct runtime dependencies
  o Ensure the master and minions all have salt installed with these same options and dependencies
  o Add the line 'transport: [tcp|raet]' to both the master and minion configuration files
  o Restart salt on the master and minions

===================================================================================================
 *  INFO: Running install_freebsd_11_stable_post()
 *  INFO: Running install_freebsd_restart_daemons()
/etc/rc.conf: firstboot-growfs=YES: not found
/etc/rc.conf: firstboot-growfs=YES: not found
Starting salt_minion.
The Salt Minion is shutdown.
/usr/local/etc/rc.d/salt_minion: WARNING: failed to start salt_minion
 *  INFO: Running daemons_running()
 *  INFO: Salt installed!
Clone salt-desktop ...
Cloning into '/srv/salt'...
remote: Enumerating objects: 24, done.
remote: Counting objects: 100% (24/24), done.
remote: Compressing objects: 100% (19/19), done.
remote: Total 208 (delta 7), reused 17 (delta 5), pack-reused 184
Receiving objects: 100% (208/208), 1.16 MiB | 70.00 KiB/s, done.
Resolving deltas: 100% (89/89), done.

For usage ideas visit ...
 https://github.com/saltstack-formulas/salt-desktop#stack-profiles

////////////////////////////////////////////////////////////////
////////////                                         ///////////  
////////////              Congratulations            ///////////  
///////////    Salt and Salt-Desktop are installed   ///////////  
///////////                                         ///////////
////////////////////////////////////////////////////////////////
```