### PR TITLE
fix(nginx): fix breaking change in upstream nginx-formula

### DIFF
--- a/profiles/example_config.sls
+++ b/profiles/example_config.sls
@@ -134,12 +134,11 @@ maven:
   archetypes: http://repository.example.com/releases/my-archetype-catalog.xml
 
 nginx:
-  ng:
-    install_from_repo: false
-    install_from_phusionpassenger: false
-    install_from_ppa: false
-    ppa_version: 'stable'
-    source_version: '1.10.0'
+  install_from_repo: false
+  install_from_phusionpassenger: false
+  install_from_ppa: false
+  ppa_version: 'stable'
+  source_version: '1.10.0'
 
 java:
   java_home: /usr/local/lib/java


### PR DESCRIPTION
Fixes this
```
 ID: nginx-deprecated-in-v1.0.0-test-fail
    Function: test.fail_without_changes
        Name:

################################################################################
#                                                                              #
#                   WARNING: BREAKING CHANGES SINCE `v1.0.0`                   #
#                                                                              #
################################################################################
#                                                                              #
# Prior to `v1.0.0`, this formula provided two methods for managing NGINX; the #
# old method under `nginx` and the new method under `nginx.ng`. The old method #
# has now been removed and `nginx.ng` has been promoted to be `nginx` in its   #
# place.                                                                       #
#                                                                              #
# If you are not in a position to migrate, please pin your repo to the final   #
# release tag before `v1.0.0`, i.e. `v0.56.1`.                                 #
#                                                                              #
# To migrate from `nginx.ng`, simply modify your pillar to promote the entire  #
# section under `nginx:ng` so that it is under `nginx` instead. So with the    #
# editor of your choice, highlight the entire section and then unindent one    #
# level. Finish by removing the `ng:` line.                                    #
#                                                                              #
# To migrate from the old `nginx`, first convert to `nginx.ng` under `v0.56.1` #
# and then follow the steps laid out in the paragraph directly above.          #
#                                                                              #
################################################################################

      Result: False
     Comment: Failure!

```