### PR TITLE
feat(python): use python3

### DIFF
--- a/bin/salt.sh
+++ b/bin/salt.sh
@@ -64,31 +64,31 @@ darwin*) OSHOME=/Users
 linux*)  OSHOME=/home
          echo "Setup Linux baseline and install saltstack masterless minion ..."
          if [ -f "/usr/bin/dnf" ]; then
-             /usr/bin/dnf install -y --best --allowerasing python-pip git wget redhat-rpm-config python-devel || exit 1 
+             /usr/bin/dnf install -y --best --allowerasing python3-pip git wget redhat-rpm-config python3-devel || exit 1 
          elif [ -f "/usr/bin/yum" ]; then
              /usr/bin/yum install -y epel-release
-             /usr/bin/yum install -y python-pip git wget redhat-rpm-config python-devel || exit 1 
+             /usr/bin/yum install -y python3-pip git wget redhat-rpm-config python3-devel || exit 1 
          elif [ -f "/usr/bin/zypper" ]; then
-             /usr/bin/zypper install -y git python-PyYAML python-devel python-pip python-curses || exit 1
-             /usr/bin/zypper remove -y python3-pip 2>/dev/null
+             /usr/bin/zypper install -y git python3-PyYAML python3-devel python3-pip python3-curses || exit 1
+             /usr/bin/zypper remove -y python2-pip 2>/dev/null
          elif [ -f "/usr/bin/apt-get" ]; then
              /usr/bin/apt autoremove -y
              /usr/bin/apt-get update --fix-missing
              ## https://github.com/pypa/pip/issues/5253 only install python-pip if pip is missing
-             which pip || /usr/bin/apt-get install -y python-pip
-             /usr/bin/apt-get install -y git ssh wget python-dev curl software-properties-common || exit 1
+             which pip || /usr/bin/apt-get install -y python3-pip
+             /usr/bin/apt-get install -y git ssh wget python3-dev curl software-properties-common || exit 1
              /usr/bin/apt-add-repository universe
              /usr/bin/apt autoremove -y
              /usr/bin/apt-get update -y
          elif [ -f "/usr/bin/pacman" ]; then
              /usr/bin/pacman-mirrors -g
              /usr/bin/pacman -Syyu --noconfirm
-             /usr/bin/pacman -S --noconfirm git python-yaml python-pip psutils || exit 1
+             /usr/bin/pacman -S --noconfirm git python3-yaml python3-pip psutils || exit 1
          fi
          pip install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          rm -f install_salt.sh 2>/dev/null
          wget -O install_salt.sh https://bootstrap.saltstack.com || exit 1
-         (sh install_salt.sh -P ${RELEASE} && rm -f install_salt.sh) || exit 1
+         (sh install_salt.sh -P ${RELEASE} -x python3 && rm -f install_salt.sh) || exit 1
          ;;
 esac
 

--- a/bin/salt.sh
+++ b/bin/salt.sh
@@ -11,7 +11,7 @@ if [ -f "/usr/bin/zypper" ]; then
     # opensuse does not have major version pegged packages support
     RELEASE=""
 else
-    RELEASE='stable 2018.3.4'
+    RELEASE='stable 2019.2.0'
 fi
 #parse commandline (not tested yet)
 while getopts ":r:" option; do
@@ -65,11 +65,11 @@ linux*)  OSHOME=/home
          echo "Setup Linux baseline and install saltstack masterless minion ..."
          if [ -f "/usr/bin/dnf" ]; then
              /usr/bin/dnf install -y --best --allowerasing python3-pip git wget redhat-rpm-config python3-devel || exit 1 
-             pip install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
+             pip3 install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          elif [ -f "/usr/bin/yum" ]; then
              /usr/bin/yum install -y epel-release
-             /usr/bin/yum install -y python3-pip git wget redhat-rpm-config python3-devel || exit 1 
-             pip install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
+             /usr/bin/yum install -y python34-pip git wget redhat-rpm-config python34-devel || exit 1 
+             pip3.4 install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          elif [ -f "/usr/bin/zypper" ]; then
              /usr/bin/zypper install -y git python3-PyYAML python3-devel python3-pip python3-curses || exit 1
              /usr/bin/zypper remove -y python2-pip 2>/dev/null
@@ -93,6 +93,17 @@ linux*)  OSHOME=/home
          rm -f install_salt.sh 2>/dev/null
          wget -O install_salt.sh https://bootstrap.saltstack.com || exit 1
          (sh install_salt.sh -x python3 -P ${RELEASE} && rm -f install_salt.sh) || exit 1
+
+         ### workaround for https://github.com/saltstack/salt-bootstrap/issues/1355
+         ### and ensure python3 is systemd default python
+         if [ -f "/usr/bin/dnf" ] || [ -f "/usr/bin/yum" ]; then
+             rm /usr/bin/python 2>/dev/null; ln -s /usr/bin/python3 /usr/bin/python
+         elif [ -f "/usr/bin/apt-get" ]; then
+             /usr/bin/apt-get remove -y python2.7 python2.7-minimal || exit 1
+             rm /usr/bin/python 2>/dev/null; ln -s /usr/bin/python3 /usr/bin/python
+         elif [ -f "/usr/bin/zypper" ]; then
+             rm /usr/bin/python 2>/dev/null; ln -s /usr/bin/python3 /usr/bin/python
+         fi
          ;;
 esac
 

--- a/bin/salt.sh
+++ b/bin/salt.sh
@@ -76,8 +76,8 @@ freebsd*|linux*)
              pip3 install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          elif [ -f "/usr/bin/yum" ]; then
              /usr/bin/yum install -y epel-release
-             /usr/bin/yum install -y python34-pip git wget redhat-rpm-config python34-devel || exit 1 
-             pip3.4 install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
+             /usr/bin/yum install -y python36-pip git wget redhat-rpm-config python36-devel || exit 1 
+             pip3.6 install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          elif [ -f "/usr/bin/zypper" ]; then
              /usr/bin/zypper install -y git python3-PyYAML python3-devel python3-pip python3-curses || exit 1
              /usr/bin/zypper remove -y python2-pip 2>/dev/null

--- a/bin/salt.sh
+++ b/bin/salt.sh
@@ -64,31 +64,35 @@ darwin*) OSHOME=/Users
 linux*)  OSHOME=/home
          echo "Setup Linux baseline and install saltstack masterless minion ..."
          if [ -f "/usr/bin/dnf" ]; then
-             /usr/bin/dnf install -y --best --allowerasing python-pip git wget redhat-rpm-config python-devel || exit 1 
+             /usr/bin/dnf install -y --best --allowerasing python3-pip git wget redhat-rpm-config python3-devel || exit 1 
+             pip install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          elif [ -f "/usr/bin/yum" ]; then
              /usr/bin/yum install -y epel-release
-             /usr/bin/yum install -y python-pip git wget redhat-rpm-config python-devel || exit 1 
+             /usr/bin/yum install -y python3-pip git wget redhat-rpm-config python3-devel || exit 1 
+             pip install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          elif [ -f "/usr/bin/zypper" ]; then
-             /usr/bin/zypper install -y git python-PyYAML python-devel python-pip python-curses || exit 1
-             /usr/bin/zypper remove -y python3-pip 2>/dev/null
+             /usr/bin/zypper install -y git python3-PyYAML python3-devel python3-pip python3-curses || exit 1
+             /usr/bin/zypper remove -y python2-pip 2>/dev/null
+             pip install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          elif [ -f "/usr/bin/apt-get" ]; then
              /usr/bin/apt autoremove -y
              /usr/bin/apt-get update --fix-missing
              ## https://github.com/pypa/pip/issues/5253 only install python-pip if pip is missing
-             which pip || /usr/bin/apt-get install -y python-pip
-             /usr/bin/apt-get install -y git ssh wget python-dev curl software-properties-common || exit 1
+             which pip || /usr/bin/apt-get install -y python3-pip
+             /usr/bin/apt-get install -y git ssh wget python3-dev curl software-properties-common || exit 1
              /usr/bin/apt-add-repository universe
              /usr/bin/apt autoremove -y
              /usr/bin/apt-get update -y
+             pip3 install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          elif [ -f "/usr/bin/pacman" ]; then
              /usr/bin/pacman-mirrors -g
              /usr/bin/pacman -Syyu --noconfirm
-             /usr/bin/pacman -S --noconfirm git python-yaml python-pip psutils || exit 1
+             /usr/bin/pacman -S --noconfirm git python3-yaml python3-pip psutils || exit 1
+             pip install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          fi
-         pip install --upgrade --ignore-installed --pre wrapper barcodenumber npyscreen || exit 1
          rm -f install_salt.sh 2>/dev/null
          wget -O install_salt.sh https://bootstrap.saltstack.com || exit 1
-         (sh install_salt.sh -P ${RELEASE} && rm -f install_salt.sh) || exit 1
+         (sh install_salt.sh -x python3 -P ${RELEASE} && rm -f install_salt.sh) || exit 1
          ;;
 esac
 


### PR DESCRIPTION
This PR installs salt with python3 per: https://github.com/saltstack/salt-bootstrap#python-3-support

We also ensure python symlink references python3
- Ubuntu 18.04 python is symlinked to python3 (but see https://github.com/saltstack/salt-bootstrap/issues/1355)
- CentOS7 and OpenSuse Leap python is symlink to python2 (but python3 is installed).


Verified on CentOS7, Ubuntu 18.04, OpenSUSE 15.0 Leap.