### PR TITLE
refactor(salter): tidyup language, hyperlinks, rebrand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,41 +1,43 @@
 =============
-salt-desktop
+salter
 =============
 
-Salt Desktop is a tool for building and deploying system environments without fuss.
+Salter is a tool for building and deploying system environments without fuss.
 
-If you are familar with yaml and want to inject dynamic profiles into your systems, this tool does that. The architectural design aims to keep users focused on profiles and associated configuration..
+If you are familar with yaml and want to inject dynamic profiles into your systems, this tool can help. The architectural design aims to keep users focused on profiles and associated configuration as much as possible.
 
-Profiles are an minimilistic way of describing a wanted software environment. They can be dynamically created, shared, and reused in a predictable manner. Configs are an interface designed to hold global values distributble to hosts. While profile defaults maybe sufficient, we often need to modify default configuration to suit site/personal specifics. Formulas are pre-written salt states developed and shared by open source communities.
+*Profiles* are an minimilistic way of describing a wanted software environment; they can be dynamically created, shared, and reused in a predictable manner. *Configs* are an interface designed to hold global values distributble to hosts, and allowing us to alter default configuration with site/personal specifics. *Formulas/States* are pre-written salt states developed by open source communities.
 
 Install
 =======
 
 ```
-curl -o salter.sh https://raw.githubusercontent.com/saltstack-formulas/salt-desktop/master/installer.sh && sudo bash salter.sh -i bootstrap && sudo bash salter.sh -i salt
+curl https://raw.githubusercontent.com/saltstack-formulas/salter/master/salter.sh && sudo bash salter.sh -i bootstrap && sudo bash salter.sh -i salter
 ```
 
 Deploy profiles
 ===============
 
-This command deploys a profile (pre-shipped or custom-built)-
+This command deploys a profile (pre-shipped or yours)-
 
 ```
 sudo /usr/local/bin/salter.sh -i <profile-name> [ -u loginname ]
 ```
 
-Dedicated upstream repositories contain the building blocks for profiles-
+Upstream community repositories contain building blocks for profiles-
 
-* `saltstack-formulas repository`_ ( default)
-* `salt-formulas repository`_
+* `saltstack-formulas`_ (default)
+* `salt-formulas`_
+* `random salt-projects`_ (random example)
 
 .. _`saltstack-formulas`: https://github.com/saltstack-formulas
 .. _`salt-formulas`: https://github.com/salt-formulas
+.. _`random salt-projects`: https://github.com/eligundry/salt.eligundry.com
 
 Integration recommendation
 ==========================
 
-Separate your business logic artifacts from the consuming system. Keep your salt-desktop artifacts in a separate git repository. You can integrate salt-desktop with your repo as follows-
+Separate business logic artifacts from the consuming system. Store your salt artifacts in a separate git repository. You can integrate salter with your repo as follows (see `Reference Solution`_)-
 
 1. Create following directories in your repository.
 
@@ -49,18 +51,17 @@ Separate your business logic artifacts from the consuming system. Keep your salt
 
 2. Move your pillars/states to these new directories.
 
-3. Overlay salt-desktop::
+3. Overlay salter::
 
-    curl -o scripts/overlay-salt.sh https://raw.githubusercontent.com/saltstack-formulas/salt-desktop/master/contrib/overlay-salt.sh
+    curl -o scripts/overlay-salt.sh https://raw.githubusercontent.com/saltstack-formulas/salter/master/contrib/overlay-salt.sh
     sudo ./scripts/overlay-salt.sh
 
-See Reference Solution at https://github.com/noelmcloughlin/salt-desktop-overlay-demo
+See `Reference Solution`_.
 
+.. _`Reference Solution`: https://github.com/noelmcloughlin/salter-overlay-demo
 
 Notes
 -----
-The `overlay-salt.sh` script merges salt-desktop into your repository and integrates your artifacts into the initial install procedure. We have provided a working example in the `contrib/` directory.
+The `overlay-salt.sh` script merges salter into your repository and integrates your artifacts into the initial install procedure. We have provided a working example in the `contrib/` directory.
 
-salt-desktop is tested on python2 and python3 (default). This tool is reported to work on MacOS, FreeBSD, and most GNU/Linux.
-
-formulas are tested by the respective developers.
+salter is tested on python2 and python3 (default). This tool is reported to work on MacOS, FreeBSD, and most GNU/Linux. Salt states/fprrmulas are tested by the respective maintainers.

--- a/contrib/design_specs/API.md
+++ b/contrib/design_specs/API.md
@@ -6,7 +6,7 @@ Description of solution Application Programming Interface (API).
 
 The command line interface is described now.
 
-- <code>installer.sh</code>
+- <code>salter.sh</code>
 
   - Bash script to install/upgrade salstack software under sudo privledges.
 

--- a/contrib/overlay-salt.sh
+++ b/contrib/overlay-salt.sh
@@ -5,7 +5,7 @@
 #   - ./profiles directory (copied to salt file_roots)
 #   - ./configs directory (copied to salt pillar_roots)
 #   - ./formulas directory (copied to salt file_roots)
-#   - ./scripts/installer.sh (a customized installer)
+#   - ./scripts/salter.sh (a customized installer)
 # This script merges both repos and installs salt-desktop
 #----------------------------------------------------------------
 git config user.email "not@important.com"                                   ##keep git happy
@@ -30,10 +30,10 @@ else
     exit 1 
 fi
 
-## Check for a contributed/custom installer.sh script and install salt
-[ -f contrib/installer.sh ] && mv contrib/installer.sh installer.sh && chmod +x installer.sh
-RC=0 && ./installer.sh -i bootstrap || exit 1
-RC=0 && ./installer.sh -i salt || exit 1
+## Check for a contributed/custom salter.sh script and install salt
+[ -f contrib/salter.sh ] && mv contrib/salter.sh salter.sh && chmod +x salter.sh
+RC=0 && ./salter.sh -i bootstrap || exit 1
+RC=0 && ./salter.sh -i salt || exit 1
 
 ## overlay contributed/custom salt formulas
 SOURCE_DIR=formulas
@@ -48,6 +48,6 @@ do
 done
 
 ## Check status/cleanup
-rm ./installer.sh 2>/dev/null
+rm ./salter.sh 2>/dev/null
 (( RC > 0 )) && echo "something is wrong" && exit ${RC}
 echo "Salter script is installed at /usr/local/bin/salter.sh"


### PR DESCRIPTION
This PR should complete change in branding.
- rename installer.sh to salter.sh
- fix url in README
- add `salter` state instead of `salt` state
- rename some variables.