### PR TITLE
allow skip broken on centos yum install

### DIFF
--- a/salter.sh
+++ b/salter.sh
@@ -115,16 +115,7 @@ pkg-add() {
                  /usr/bin/dnf install -y --best --allowerasing ${PACKAGES} || exit 1
              elif [ -f "/usr/bin/yum" ]; then
                  /usr/bin/yum update -y || exit 1
-                 /usr/bin/yum install -y ${PACKAGES} yum-utils
-                 (( $? >= 0 )) && echo "failed to install ${PACKAGES}" && exit 1
-                 ## here we are installing git 2.x
-                 /usr/bin/yum install centos-release-scl -y
-                 (( $? >= 0 )) && echo "failed to install software collections" && exit 1
-                 RHVERSION="$(grep -i 'inux release ' /etc/redhat-release  |awk '{print $4}' |cut -d. -f1)"
-                 /usr/bin/yum-config-manager --enable rhel-server-rhscl-${RHVERSION}-rpms
-                 ## git v29 is available in scl
-                 /usr/bin/yum install rh-git29 -y | exit 1
-                 /usr/bin/scl enable rh-git29 bash | exit 1
+                 /usr/bin/yum install -y ${PACKAGES} --skip-broken || exit 1
              elif [[ -f "/usr/bin/apt-get" ]]; then
                  /usr/bin/apt-get update --fix-missing -y || exit 1
                  /usr/bin/apt-add-repository universe
@@ -576,7 +567,6 @@ cli-options() {
     *)                      usage ;;
     esac
     PROFILE="$( echo ${1%%.*} )"
-    shift   #check for options
 
     while getopts ":i:l:u:" option; do
         case "${option}" in

--- a/salter.sh
+++ b/salter.sh
@@ -115,7 +115,16 @@ pkg-add() {
                  /usr/bin/dnf install -y --best --allowerasing ${PACKAGES} || exit 1
              elif [ -f "/usr/bin/yum" ]; then
                  /usr/bin/yum update -y || exit 1
-                 /usr/bin/yum install -y ${PACKAGES} || exit 1
+                 /usr/bin/yum install -y ${PACKAGES} yum-utils
+                 (( $? >= 0 )) && echo "failed to install ${PACKAGES}" && exit 1
+                 ## here we are installing git 2.x
+                 /usr/bin/yum install centos-release-scl -y
+                 (( $? >= 0 )) && echo "failed to install software collections" && exit 1
+                 RHVERSION="$(grep -i 'inux release ' /etc/redhat-release  |awk '{print $4}' |cut -d. -f1)"
+                 /usr/bin/yum-config-manager --enable rhel-server-rhscl-${RHVERSION}-rpms
+                 ## git v29 is available in scl
+                 /usr/bin/yum install rh-git29 -y | exit 1
+                 /usr/bin/scl enable rh-git29 bash | exit 1
              elif [[ -f "/usr/bin/apt-get" ]]; then
                  /usr/bin/apt-get update --fix-missing -y || exit 1
                  /usr/bin/apt-add-repository universe

--- a/salter.sh
+++ b/salter.sh
@@ -567,6 +567,7 @@ cli-options() {
     *)                      usage ;;
     esac
     PROFILE="$( echo ${1%%.*} )"
+    shift   #check for options
 
     while getopts ":i:l:u:" option; do
         case "${option}" in

--- a/salter.sh
+++ b/salter.sh
@@ -115,7 +115,7 @@ pkg-add() {
                  /usr/bin/dnf install -y --best --allowerasing ${PACKAGES} || exit 1
              elif [ -f "/usr/bin/yum" ]; then
                  /usr/bin/yum update -y || exit 1
-                 /usr/bin/yum install -y ${PACKAGES} || exit 1
+                 /usr/bin/yum install -y ${PACKAGES} --skip-broken || exit 1
              elif [[ -f "/usr/bin/apt-get" ]]; then
                  /usr/bin/apt-get update --fix-missing -y || exit 1
                  /usr/bin/apt-add-repository universe


### PR DESCRIPTION
This PR fixes a git conflict on CentOS7 when using yum.
```
---> Package zip.x86_64 0:3.0-11.el7 will be installed
--> Processing Conflict: git2u-2.16.5-1.ius.el7.x86_64 conflicts git < 2.16.5
--> Processing Conflict: git2u-perl-Git-2.16.5-1.ius.el7.noarch conflicts perl-Git < 2.16.5
--> Processing Conflict: git2u-core-2.16.5-1.ius.el7.x86_64 conflicts git-core < 2.16.5
--> Finished Dependency Resolution
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```
### PR progress checklist (to be filled in by reviewers)

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [x] Reviews completed

---

### What type of PR is this?
Workaround yum warning on CentOS

#### Primary type
- [x]      A bug fix

#### Secondary type

### Does this PR introduce a `BREAKING CHANGE`?
No.

### Related issues and/or pull requests



### Describe the changes you're proposing

CentOS 7 only ships git v1.8 so typically we install git 2.x from IUS repo.  This causes a problem with `salter.sh bootstrap` command because its trying to install git but there is conflict.  One solution is to not install git (it maybe already installed) but that approach impacts all OS.  The most clean solution is to allows `skip-broken` because only a limited number of packages are being installed at the step that fails.


### Pillar / config required to test the proposed change

### Debug log showing how the proposed changes work
```
--> Running transaction check
---> Package dwz.x86_64 0:0.11-3.el7 will be installed
---> Package perl-srpm-macros.noarch 0:1-8.el7 will be installed
---> Package python-srpm-macros.noarch 0:3-32.el7 will be installed
---> Package redhat-rpm-config.noarch 0:9.1.0-88.el7.centos will be installed
---> Package zip.x86_64 0:3.0-11.el7 will be installed
--> Finished Dependency Resolution

Packages skipped because of dependency problems:
    git-1.8.3.1-20.el7.x86_64 from base
    perl-Git-1.8.3.1-20.el7.noarch from base

Dependencies Resolved

===============================================================================================================
 Package                         Arch                Version                           Repository         Size
===============================================================================================================
Installing:
 redhat-rpm-config               noarch              9.1.0-88.el7.centos               base               81 k
Installing for dependencies:
 dwz                             x86_64              0.11-3.el7                        base               99 k
 perl-srpm-macros                noarch              1-8.el7                           base              4.6 k
 python-srpm-macros              noarch              3-32.el7                          base              8.4 k
 zip                             x86_64              3.0-11.el7                        base              260 k
Skipped (dependency problems):
 git                             x86_64              1.8.3.1-20.el7                    base              4.4 M
 perl-Git                        noarch              1.8.3.1-20.el7                    base               55 k

Transaction Summary
===============================================================================================================
Install                        1 Package  (+4 Dependent packages)
Skipped (dependency problems)  2 Packages

Total download size: 453 k
Installed size: 1.2 M
Downloading packages:
(1/5): python-srpm-macros-3-32.el7.noarch.rpm                                           | 8.4 kB  00:00:00     
(2/5): dwz-0.11-3.el7.x86_64.rpm                                                        |  99 kB  00:00:00     
(3/5): redhat-rpm-config-9.1.0-88.el7.centos.noarch.rpm                                 |  81 kB  00:00:00     
(4/5): zip-3.0-11.el7.x86_64.rpm                                                        | 260 kB  00:00:00     
(5/5): perl-srpm-macros-1-8.el7.noarch.rpm                                              | 4.6 kB  00:00:01     
---------------------------------------------------------------------------------------------------------------
Total                                                                          274 kB/s | 453 kB  00:00:01     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : python-srpm-macros-3-32.el7.noarch                                                          1/5 
  Installing : dwz-0.11-3.el7.x86_64                                                                       2/5 
  Installing : zip-3.0-11.el7.x86_64                                                                       3/5 
  Installing : perl-srpm-macros-1-8.el7.noarch                                                             4/5 
  Installing : redhat-rpm-config-9.1.0-88.el7.centos.noarch                                                5/5 
  Verifying  : perl-srpm-macros-1-8.el7.noarch                                                             1/5 
  Verifying  : zip-3.0-11.el7.x86_64                                                                       2/5 
  Verifying  : dwz-0.11-3.el7.x86_64                                                                       3/5 
  Verifying  : python-srpm-macros-3-32.el7.noarch                                                          4/5 
  Verifying  : redhat-rpm-config-9.1.0-88.el7.centos.noarch                                                5/5 

Installed:
  redhat-rpm-config.noarch 0:9.1.0-88.el7.centos                                                               

Dependency Installed:
  dwz.x86_64 0:0.11-3.el7      perl-srpm-macros.noarch 0:1-8.el7      python-srpm-macros.noarch 0:3-32.el7     
  zip.x86_64 0:3.0-11.el7     

Skipped (dependency problems):
  git.x86_64 0:1.8.3.1-20.el7                         perl-Git.noarch 0:1.8.3.1-20.el7 
```

### Testing checklist

- [x] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).


### Additional context

